### PR TITLE
Use intptr_t rather than long

### DIFF
--- a/zbar/decoder.c
+++ b/zbar/decoder.c
@@ -24,6 +24,7 @@
 #include <config.h>
 #include <stdlib.h>     /* malloc, calloc, free */
 #include <stdio.h>      /* snprintf */
+#include <stdint.h>     /* intptr_t */
 #include <string.h>     /* memset, strlen */
 
 #include <zbar.h>

--- a/zbar/decoder.c
+++ b/zbar/decoder.c
@@ -109,7 +109,7 @@ void zbar_decoder_destroy (zbar_decoder_t *dcode)
 
 void zbar_decoder_reset (zbar_decoder_t *dcode)
 {
-    memset(dcode, 0, (long)&dcode->buf_alloc - (long)dcode);
+    memset(dcode, 0, (intptr_t)&dcode->buf_alloc - (intptr_t)dcode);
 #ifdef ENABLE_EAN
     ean_reset(&dcode->ean);
 #endif

--- a/zbar/decoder.c
+++ b/zbar/decoder.c
@@ -24,7 +24,9 @@
 #include <config.h>
 #include <stdlib.h>     /* malloc, calloc, free */
 #include <stdio.h>      /* snprintf */
-#include <stdint.h>     /* intptr_t */
+#if defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L)
+    #include <stdint.h>     /* intptr_t */
+#endif
 #include <string.h>     /* memset, strlen */
 
 #include <zbar.h>
@@ -110,7 +112,11 @@ void zbar_decoder_destroy (zbar_decoder_t *dcode)
 
 void zbar_decoder_reset (zbar_decoder_t *dcode)
 {
+#ifdef INTPTR_MIN
     memset(dcode, 0, (intptr_t)&dcode->buf_alloc - (intptr_t)dcode);
+#else
+    memset(dcode, 0, (long)&dcode->buf_alloc - (long)dcode);
+#endif
 #ifdef ENABLE_EAN
     ean_reset(&dcode->ean);
 #endif


### PR DESCRIPTION
If you want to cast from a pointer type to an integer type, you might have to use `intptr_t` or `uintptr_t`. Otherwise, the 64-bit compiler warns.