### PR TITLE
Fix jpeg.c type mismatch

### DIFF
--- a/zbar/jpeg.c
+++ b/zbar/jpeg.c
@@ -68,7 +68,7 @@ void init_source (j_decompress_ptr cinfo)
     cinfo->src->bytes_in_buffer = img->datalen;
 }
 
-int fill_input_buffer (j_decompress_ptr cinfo)
+boolean fill_input_buffer (j_decompress_ptr cinfo)
 {
     /* buffer underrun error case */
     cinfo->src->next_input_byte = fake_eoi;


### PR DESCRIPTION
Hello, I'm katahiromz.

The return value of `fill_input_buffer` function seems like a `boolean`. Can you fix it?